### PR TITLE
feat: Prevent http_anonymous user from receiving the creator role.

### DIFF
--- a/src/lib/Gitolite/Conf/Load.pm
+++ b/src/lib/Gitolite/Conf/Load.pm
@@ -521,9 +521,10 @@ sub user_roles {
     # - else give everyone read access to everything
     my @retval = ( '@READERS' );
 
-    # - and give owners '@CREATOR' access to their repos
+    # - and give owners '@CREATOR' access to their repos 
+    # - http_anonymous user should never receive a CREATOR role
     my ( $owner, $project ) = split('/', $repo, 2);
-    if ( $owner eq $user ) {
+    if ( $owner eq $user and $user ne 'http_anonymous') {
         push @retval, '@CREATOR';
     }
     if (0) { # Change to 1 to enable debug.


### PR DESCRIPTION
Fixes https://github.com/flox/floxEM/issues/301

This updates the role assignments for the http_anonymous user. Instead of the CREATOR role, it now only receives the READERS role. This change prevents unintended branch creation and potential security risks, ensuring read-only access as intended.